### PR TITLE
fixed type error with doc.previous_hours

### DIFF
--- a/swiss_accounting_software/swiss_qr_bill/doctype/swiss_hours_calculation/swiss_hours_calculation.py
+++ b/swiss_accounting_software/swiss_qr_bill/doctype/swiss_hours_calculation/swiss_hours_calculation.py
@@ -197,7 +197,9 @@ def calculate_hours_for_employee(doc):
 	# Dont need the new balance if the setting forbids it
 	if calculation_setting.count_balance == 0:
 		doc.new_balance = 0.0
-	else: 
+	else:
+		if doc.previous_hours is None:
+			doc.previous_hours = 0 
 		doc.new_balance = doc.previous_hours + worked_hours - required_work_hours_total
 
 	# Finally set the calculation status to done


### PR DESCRIPTION
If I checked the box for count balance, I always got an error with unsupported operand types. After some investigation i saw that it picks the doc.previous_hours which (in my opinion) does not exist, if it is the first one. So i added a check if previous_hours is None.